### PR TITLE
Rebuild monitoring platform as Node.js web app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Server configuration
+PORT=3000
+TIMEZONE=Europe/Madrid
+
+# Email configuration
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your-user
+SMTP_PASS=your-password
+SMTP_FROM="Web Monitor <monitor@example.com>"
+
+# Puppeteer options
+CHROME_EXECUTABLE_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.env
+storage/**
+!storage/
+!storage/screenshots/
+!storage/screenshots/.gitkeep
+!storage/digests/
+!storage/digests/.gitkeep

--- a/README.md
+++ b/README.md
@@ -1,1 +1,79 @@
-# prueba
+# Web Monitoring Platform
+
+Aplicación web completa para registrar sitios web, capturarlos diariamente y enviar informes por correo electrónico.
+
+## Características
+
+- CRUD para administrar los sitios web a monitorizar y el correo de destino.
+- Captura automática diaria (10:00) de cada sitio mediante Puppeteer.
+- Envío del pantallazo diario por correo electrónico.
+- Digest mensual en PDF con las últimas 30 capturas.
+- Interfaz web sencilla incluida (sin dependencias externas) para gestionar los registros.
+
+## Requisitos previos
+
+- Node.js 18 o superior.
+- Navegador Chromium disponible (Puppeteer descarga uno automáticamente en la instalación).
+- Credenciales SMTP válidas para el envío de correos.
+
+## Configuración
+
+1. Clona el repositorio y entra en la carpeta del proyecto.
+   ```bash
+   git clone <tu-fork>
+   cd prueba
+   ```
+2. Crea el archivo de variables de entorno.
+   ```bash
+   cp .env.example .env
+   ```
+3. Edita `.env` con tu configuración:
+   - `PORT`: puerto del servidor web.
+   - `TIMEZONE`: zona horaria IANA usada por el planificador (por defecto `Europe/Madrid`).
+   - Credenciales SMTP (`SMTP_*`).
+   - Opcionalmente `CHROME_EXECUTABLE_PATH` si deseas usar un navegador existente.
+4. Instala dependencias.
+   ```bash
+   npm install
+   ```
+
+## Uso
+
+1. Inicia el servidor.
+   ```bash
+   npm run dev
+   ```
+2. Abre tu navegador y visita `http://localhost:3000` (o el puerto configurado).
+3. Desde la interfaz podrás:
+   - Añadir nuevas webs introduciendo la URL y el correo destinatario.
+   - Editar o eliminar webs existentes.
+   - Consultar el historial de capturas de cada web.
+
+El planificador arranca automáticamente al iniciar el servidor. A las 10:00 de cada día (según `TIMEZONE`) se realizará la captura, se enviará un correo con la imagen y, tras acumular 30 capturas, se generará y enviará un PDF.
+
+## Scripts disponibles
+
+- `npm start`: ejecuta el servidor en modo producción.
+- `npm run dev`: usa `nodemon` para reiniciar el servidor en caliente.
+- `npm run check`: validación sintáctica rápida de los archivos JavaScript.
+
+## Estructura del proyecto
+
+```
+prueba/
+├── public/              # Interfaz web
+├── scripts/             # Utilidades (p. ej. verificación sintáctica)
+├── src/                 # Código del backend Express
+│   ├── routes/
+│   ├── services/
+│   ├── scheduler.js
+│   ├── server.js
+│   └── ...
+└── storage/             # Capturas y digest generados (ignorado por git)
+```
+
+## Notas
+
+- Las capturas, PDFs y datos de la aplicación se guardan en `storage/`. Se recomienda montar un volumen persistente en despliegues productivos.
+- Si no se configura SMTP, los envíos de correo se omitirán (se registrará un aviso en consola).
+- Para entornos sin interfaz gráfica, establece `CHROME_EXECUTABLE_PATH` a un binario de Chromium válido o usa Puppeteer con `PUPPETEER_EXECUTABLE_PATH`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "web-monitoring-platform",
+  "version": "1.0.0",
+  "description": "Website monitoring platform with scheduled screenshots and email digests.",
+  "type": "commonjs",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "dev": "nodemon src/server.js",
+    "check": "node scripts/check.js"
+  },
+  "keywords": [
+    "website",
+    "monitoring",
+    "screenshots",
+    "scheduler",
+    "express"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "dayjs": "^1.11.10",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "node-cron": "^3.0.3",
+    "nodemailer": "^6.9.13",
+    "pdfkit": "^0.15.0",
+    "puppeteer": "^22.8.1"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.4"
+  }
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,126 @@
+const createForm = document.querySelector('#create-form');
+const refreshButton = document.querySelector('#refresh');
+const websitesContainer = document.querySelector('#websites');
+const template = document.querySelector('#website-template');
+const capturesCard = document.querySelector('#captures-card');
+const capturesContainer = document.querySelector('#captures');
+const closeCaptures = document.querySelector('#close-captures');
+
+async function fetchJSON(url, options) {
+  const response = await fetch(url, {
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    ...options
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.message || 'Error de red');
+  }
+  return response.json();
+}
+
+async function loadWebsites() {
+  websitesContainer.innerHTML = '<p>Cargando...</p>';
+  try {
+    const websites = await fetchJSON('/api/websites');
+    if (!websites.length) {
+      websitesContainer.innerHTML = '<p>No hay webs registradas todavía.</p>';
+      return;
+    }
+    websitesContainer.innerHTML = '';
+    websites.forEach(website => {
+      const node = template.content.cloneNode(true);
+      node.querySelector('.website').dataset.id = website.id;
+      node.querySelector('.website__url').textContent = website.url;
+      node.querySelector('.website__email').textContent = `Destino: ${website.recipient_email}`;
+      node.querySelector('.edit').addEventListener('click', () => openEditModal(website));
+      node.querySelector('.delete').addEventListener('click', () => deleteWebsite(website.id));
+      node.querySelector('.show-captures').addEventListener('click', () => showCaptures(website.id));
+      websitesContainer.appendChild(node);
+    });
+  } catch (error) {
+    websitesContainer.innerHTML = `<p class="error">${error.message}</p>`;
+  }
+}
+
+async function createWebsite(event) {
+  event.preventDefault();
+  const formData = new FormData(createForm);
+  const payload = {
+    url: formData.get('url'),
+    recipientEmail: formData.get('recipientEmail')
+  };
+  try {
+    await fetchJSON('/api/websites', {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    });
+    createForm.reset();
+    await loadWebsites();
+  } catch (error) {
+    alert(error.message);
+  }
+}
+
+async function deleteWebsite(id) {
+  if (!confirm('¿Eliminar esta web?')) return;
+  try {
+    await fetch(`/api/websites/${id}`, { method: 'DELETE' });
+    await loadWebsites();
+  } catch (error) {
+    alert(error.message);
+  }
+}
+
+function openEditModal(website) {
+  const url = prompt('Nueva URL', website.url);
+  if (!url) return;
+  const recipientEmail = prompt('Nuevo correo destinatario', website.recipient_email);
+  if (!recipientEmail) return;
+  fetchJSON(`/api/websites/${website.id}`, {
+    method: 'PUT',
+    body: JSON.stringify({ url, recipientEmail })
+  })
+    .then(loadWebsites)
+    .catch(error => alert(error.message));
+}
+
+async function showCaptures(id) {
+  capturesCard.hidden = false;
+  capturesContainer.innerHTML = '<p>Cargando capturas...</p>';
+  try {
+    const captures = await fetchJSON(`/api/websites/${id}/captures`);
+    if (!captures.length) {
+      capturesContainer.innerHTML = '<p>No hay capturas todavía.</p>';
+      return;
+    }
+    capturesContainer.innerHTML = '';
+    captures.forEach(capture => {
+      const article = document.createElement('article');
+      article.className = 'capture';
+      const img = document.createElement('img');
+      img.src = capture.image_url;
+      img.alt = `Captura del ${capture.captured_at_formatted}`;
+      const meta = document.createElement('div');
+      meta.className = 'capture__meta';
+      meta.innerHTML = `
+        <strong>${capture.captured_at_formatted}</strong>
+        <a href="${capture.image_url}" download>Descargar</a>
+      `;
+      article.appendChild(img);
+      article.appendChild(meta);
+      capturesContainer.appendChild(article);
+    });
+  } catch (error) {
+    capturesContainer.innerHTML = `<p class="error">${error.message}</p>`;
+  }
+}
+
+createForm.addEventListener('submit', createWebsite);
+refreshButton.addEventListener('click', loadWebsites);
+closeCaptures.addEventListener('click', () => {
+  capturesCard.hidden = true;
+});
+
+loadWebsites();

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web Monitoring Platform</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Web Monitoring Platform</h1>
+      <p>Administra tus webs monitorizadas y revisa el histórico de capturas.</p>
+    </header>
+
+    <main>
+      <section class="card">
+        <h2>Añadir nueva web</h2>
+        <form id="create-form">
+          <div class="field">
+            <label for="url">URL</label>
+            <input id="url" name="url" type="url" required placeholder="https://ejemplo.com" />
+          </div>
+          <div class="field">
+            <label for="recipientEmail">Correo destinatario</label>
+            <input id="recipientEmail" name="recipientEmail" type="email" required placeholder="usuario@dominio.com" />
+          </div>
+          <button type="submit">Guardar</button>
+        </form>
+      </section>
+
+      <section class="card">
+        <div class="card-header">
+          <h2>Webs monitorizadas</h2>
+          <button id="refresh">Actualizar</button>
+        </div>
+        <div id="websites" class="list"></div>
+      </section>
+
+      <section class="card" id="captures-card" hidden>
+        <div class="card-header">
+          <h2>Capturas recientes</h2>
+          <button id="close-captures">Cerrar</button>
+        </div>
+        <div id="captures" class="captures"></div>
+      </section>
+    </main>
+
+    <template id="website-template">
+      <article class="website">
+        <div>
+          <h3 class="website__url"></h3>
+          <p class="website__email"></p>
+        </div>
+        <div class="website__actions">
+          <button class="show-captures">Ver capturas</button>
+          <button class="edit">Editar</button>
+          <button class="delete">Eliminar</button>
+        </div>
+      </article>
+    </template>
+
+    <script src="/app.js" type="module"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,158 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f5f6fa;
+  color: #1f2937;
+}
+
+body {
+  margin: 0;
+}
+
+header {
+  padding: 2rem 1.5rem 1rem;
+  text-align: center;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: white;
+}
+
+main {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background: white;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.card-header h2 {
+  margin: 0;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+input {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #d1d5db;
+  font-size: 1rem;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: white;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(37, 99, 235, 0.25);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.website {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  gap: 1rem;
+}
+
+.website__url {
+  margin: 0 0 0.4rem;
+}
+
+.website__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.website__actions button {
+  background: #1f2937;
+}
+
+.website__actions button.show-captures {
+  background: linear-gradient(135deg, #059669, #10b981);
+}
+
+.website__actions button.delete {
+  background: linear-gradient(135deg, #dc2626, #ef4444);
+}
+
+.captures {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+}
+
+.capture {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow: hidden;
+  background: white;
+  display: flex;
+  flex-direction: column;
+}
+
+.capture img {
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+}
+
+.capture__meta {
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 600px) {
+  main {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .website {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .website__actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+}

--- a/scripts/check.js
+++ b/scripts/check.js
@@ -1,0 +1,27 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const roots = ['src', 'public'];
+
+function collectFiles(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.flatMap(entry => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return collectFiles(fullPath);
+    }
+    if (entry.isFile() && entry.name.endsWith('.js')) {
+      return [fullPath];
+    }
+    return [];
+  });
+}
+
+const files = roots.flatMap(root => collectFiles(path.join(process.cwd(), root)));
+
+files.forEach(file => {
+  execSync(`node --check "${file}"`, { stdio: 'inherit' });
+});
+
+console.log('Syntax check completed for', files.length, 'files.');

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const express = require('express');
+const websitesRouter = require('./routes/websites');
+const logger = require('./logger');
+
+const app = express();
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+app.use((req, res, next) => {
+  logger.info(`${req.method} ${req.url}`);
+  next();
+});
+
+app.use('/api/websites', websitesRouter);
+
+app.use('/storage', express.static(path.join(__dirname, '..', 'storage')));
+app.use(express.static(path.join(__dirname, '..', 'public')));
+
+app.use((err, req, res, next) => {
+  logger.error('Unhandled error', { error: err.message });
+  res.status(500).json({ message: 'Error interno del servidor' });
+});
+
+module.exports = app;

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,21 @@
+const path = require('path');
+const dotenv = require('dotenv');
+
+dotenv.config({ path: path.resolve(process.cwd(), '.env') });
+
+const config = {
+  port: parseInt(process.env.PORT || '3000', 10),
+  timezone: process.env.TIMEZONE || 'Europe/Madrid',
+  smtp: {
+    host: process.env.SMTP_HOST,
+    port: process.env.SMTP_PORT ? parseInt(process.env.SMTP_PORT, 10) : undefined,
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+    from: process.env.SMTP_FROM || 'Web Monitor <no-reply@example.com>'
+  },
+  puppeteer: {
+    executablePath: process.env.CHROME_EXECUTABLE_PATH || process.env.PUPPETEER_EXECUTABLE_PATH || undefined
+  }
+};
+
+module.exports = config;

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,14 @@
+const dayjs = require('dayjs');
+
+function log(level, message, meta) {
+  const timestamp = dayjs().toISOString();
+  const payload = meta ? ` ${JSON.stringify(meta)}` : '';
+  // eslint-disable-next-line no-console
+  console.log(`[${timestamp}] [${level.toUpperCase()}] ${message}${payload}`);
+}
+
+module.exports = {
+  info: (msg, meta) => log('info', msg, meta),
+  warn: (msg, meta) => log('warn', msg, meta),
+  error: (msg, meta) => log('error', msg, meta)
+};

--- a/src/models.js
+++ b/src/models.js
@@ -1,0 +1,114 @@
+const dayjs = require('dayjs');
+const path = require('path');
+const storage = require('./storage');
+
+function listWebsites() {
+  const data = storage.read();
+  return data.websites.map(website => ({
+    ...website,
+    created_at: dayjs(website.created_at).toISOString(),
+    last_digest_at: website.last_digest_at ? dayjs(website.last_digest_at).toISOString() : null
+  }));
+}
+
+function nextId(items) {
+  return items.length ? Math.max(...items.map(item => item.id)) + 1 : 1;
+}
+
+function createWebsite({ url, recipientEmail }) {
+  const data = storage.read();
+  const website = {
+    id: nextId(data.websites),
+    url,
+    recipient_email: recipientEmail,
+    created_at: dayjs().toISOString(),
+    last_digest_at: null
+  };
+  data.websites.push(website);
+  storage.write(data);
+  return { ...website };
+}
+
+function findWebsite(id) {
+  const data = storage.read();
+  const website = data.websites.find(item => item.id === Number(id));
+  if (!website) return null;
+  return { ...website };
+}
+
+function updateWebsite(id, { url, recipientEmail }) {
+  const data = storage.read();
+  const index = data.websites.findIndex(item => item.id === Number(id));
+  if (index === -1) return null;
+  data.websites[index] = {
+    ...data.websites[index],
+    url,
+    recipient_email: recipientEmail
+  };
+  storage.write(data);
+  return { ...data.websites[index] };
+}
+
+function deleteWebsite(id) {
+  const data = storage.read();
+  data.websites = data.websites.filter(item => item.id !== Number(id));
+  data.captures = data.captures.filter(item => item.website_id !== Number(id));
+  storage.write(data);
+}
+
+function recordCapture(websiteId, imagePath, capturedAt) {
+  const data = storage.read();
+  data.captures.push({
+    id: nextId(data.captures),
+    website_id: Number(websiteId),
+    image_path: imagePath,
+    captured_at: capturedAt
+  });
+  storage.write(data);
+}
+
+function listCaptures(websiteId) {
+  const data = storage.read();
+  return data.captures
+    .filter(capture => capture.website_id === Number(websiteId))
+    .sort((a, b) => dayjs(b.captured_at).valueOf() - dayjs(a.captured_at).valueOf())
+    .map(capture => ({
+      ...capture,
+      image_url: `/storage/${path.relative(path.join(__dirname, '..', 'storage'), capture.image_path).replace(/\\/g, '/')}`
+    }));
+}
+
+function recentCaptures(websiteId, limit = 30) {
+  return listCaptures(websiteId)
+    .slice(0, limit)
+    .map(capture => ({
+      ...capture,
+      image_url: undefined
+    }));
+}
+
+function capturesSince(websiteId, isoDate) {
+  const captures = listCaptures(websiteId);
+  return captures.filter(capture => dayjs(capture.captured_at).isAfter(dayjs(isoDate))).length;
+}
+
+function updateDigestTimestamp(websiteId, isoDate) {
+  const data = storage.read();
+  const index = data.websites.findIndex(item => item.id === Number(websiteId));
+  if (index === -1) return;
+  data.websites[index].last_digest_at = isoDate;
+  storage.write(data);
+}
+
+module.exports = {
+  listWebsites,
+  createWebsite,
+  findWebsite,
+  updateWebsite,
+  deleteWebsite,
+  recordCapture,
+  listCaptures,
+  recentCaptures,
+  capturesSince,
+  updateDigestTimestamp
+};

--- a/src/routes/websites.js
+++ b/src/routes/websites.js
@@ -1,0 +1,55 @@
+const express = require('express');
+const dayjs = require('dayjs');
+const models = require('../models');
+
+const router = express.Router();
+
+router.get('/', (req, res) => {
+  res.json(models.listWebsites());
+});
+
+router.post('/', (req, res) => {
+  const { url, recipientEmail } = req.body;
+  if (!url || !recipientEmail) {
+    return res.status(400).json({ message: 'url y recipientEmail son obligatorios.' });
+  }
+  const created = models.createWebsite({ url, recipientEmail });
+  return res.status(201).json(created);
+});
+
+router.get('/:id', (req, res) => {
+  const website = models.findWebsite(req.params.id);
+  if (!website) return res.status(404).json({ message: 'No encontrado' });
+  const captures = models.listCaptures(website.id);
+  return res.json({ ...website, captures });
+});
+
+router.put('/:id', (req, res) => {
+  const { url, recipientEmail } = req.body;
+  if (!url || !recipientEmail) {
+    return res.status(400).json({ message: 'url y recipientEmail son obligatorios.' });
+  }
+  const website = models.findWebsite(req.params.id);
+  if (!website) return res.status(404).json({ message: 'No encontrado' });
+  const updated = models.updateWebsite(req.params.id, { url, recipientEmail });
+  return res.json(updated);
+});
+
+router.delete('/:id', (req, res) => {
+  const website = models.findWebsite(req.params.id);
+  if (!website) return res.status(404).json({ message: 'No encontrado' });
+  models.deleteWebsite(req.params.id);
+  return res.status(204).send();
+});
+
+router.get('/:id/captures', (req, res) => {
+  const website = models.findWebsite(req.params.id);
+  if (!website) return res.status(404).json({ message: 'No encontrado' });
+  const captures = models.listCaptures(website.id).map(capture => ({
+    ...capture,
+    captured_at_formatted: dayjs(capture.captured_at).format('YYYY-MM-DD HH:mm:ss')
+  }));
+  return res.json(captures);
+});
+
+module.exports = router;

--- a/src/scheduler.js
+++ b/src/scheduler.js
@@ -1,0 +1,67 @@
+const cron = require('node-cron');
+const dayjs = require('dayjs');
+const utc = require('dayjs/plugin/utc');
+const timezone = require('dayjs/plugin/timezone');
+const config = require('./config');
+const logger = require('./logger');
+const models = require('./models');
+const screenshotService = require('./services/screenshot');
+const emailService = require('./services/email');
+const pdfService = require('./services/pdf');
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+dayjs.tz.setDefault(config.timezone);
+
+async function processWebsite(website) {
+  try {
+    const capturedAt = dayjs().toISOString();
+    const imagePath = await screenshotService.capture(website.url, website.id);
+    models.recordCapture(website.id, imagePath, capturedAt);
+
+    await emailService.sendScreenshotEmail({
+      to: website.recipient_email,
+      url: website.url,
+      imagePath,
+      capturedAt
+    });
+
+    const since = website.last_digest_at || dayjs().subtract(30, 'day').toISOString();
+    const captures = models.recentCaptures(website.id, 30);
+    const countSince = models.capturesSince(website.id, since);
+    if (captures.length >= 30 && countSince >= 30) {
+      const periodStart = captures[captures.length - 1].captured_at;
+      const periodEnd = captures[0].captured_at;
+      const pdfPath = await pdfService.buildDigest(website.id, website.url, captures.slice().reverse());
+      await emailService.sendDigestEmail({
+        to: website.recipient_email,
+        url: website.url,
+        pdfPath,
+        periodStart,
+        periodEnd
+      });
+      models.updateDigestTimestamp(website.id, capturedAt);
+    }
+  } catch (error) {
+    logger.error('Error processing website', { id: website.id, error: error.message });
+  }
+}
+
+function startScheduler() {
+  const task = cron.schedule('0 10 * * *', async () => {
+    logger.info('Running daily capture task');
+    const websites = models.listWebsites();
+    for (const website of websites) {
+      // eslint-disable-next-line no-await-in-loop
+      await processWebsite(website);
+    }
+  }, {
+    timezone: config.timezone
+  });
+
+  logger.info('Scheduler initialized', { timezone: config.timezone, schedule: '0 10 * * *' });
+  return task;
+}
+
+module.exports = { startScheduler };

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,21 @@
+const http = require('http');
+const app = require('./app');
+const config = require('./config');
+const logger = require('./logger');
+const { startScheduler } = require('./scheduler');
+const screenshotService = require('./services/screenshot');
+
+const server = http.createServer(app);
+
+server.listen(config.port, () => {
+  logger.info(`Servidor escuchando en http://localhost:${config.port}`);
+  startScheduler();
+});
+
+process.on('SIGINT', async () => {
+  logger.info('Shutting down gracefully');
+  await screenshotService.shutdown();
+  server.close(() => {
+    process.exit(0);
+  });
+});

--- a/src/services/email.js
+++ b/src/services/email.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const nodemailer = require('nodemailer');
+const config = require('../config');
+const logger = require('../logger');
+
+let transporter;
+
+function getTransporter() {
+  if (!config.smtp.host) {
+    logger.warn('SMTP configuration missing. Emails will be skipped.');
+    return null;
+  }
+  if (transporter) return transporter;
+  transporter = nodemailer.createTransport({
+    host: config.smtp.host,
+    port: config.smtp.port || 587,
+    secure: (config.smtp.port || 587) === 465,
+    auth: config.smtp.user && config.smtp.pass ? {
+      user: config.smtp.user,
+      pass: config.smtp.pass
+    } : undefined
+  });
+  return transporter;
+}
+
+async function sendScreenshotEmail({ to, url, imagePath, capturedAt }) {
+  const mailer = getTransporter();
+  if (!mailer) return false;
+  const info = await mailer.sendMail({
+    from: config.smtp.from,
+    to,
+    subject: `Captura diaria - ${url}`,
+    text: `Se adjunta la captura del ${capturedAt} para ${url}.`,
+    attachments: [
+      {
+        filename: imagePath.split('/').pop(),
+        path: imagePath
+      }
+    ]
+  });
+  logger.info('Screenshot email sent', { to, messageId: info.messageId });
+  return true;
+}
+
+async function sendDigestEmail({ to, url, pdfPath, periodStart, periodEnd }) {
+  const mailer = getTransporter();
+  if (!mailer) return false;
+  if (!fs.existsSync(pdfPath)) {
+    throw new Error(`PDF file not found at ${pdfPath}`);
+  }
+  const info = await mailer.sendMail({
+    from: config.smtp.from,
+    to,
+    subject: `Resumen mensual - ${url}`,
+    text: `Se adjunta el resumen de capturas entre ${periodStart} y ${periodEnd}.`,
+    attachments: [
+      {
+        filename: pdfPath.split('/').pop(),
+        path: pdfPath
+      }
+    ]
+  });
+  logger.info('Digest email sent', { to, messageId: info.messageId });
+  return true;
+}
+
+module.exports = { sendScreenshotEmail, sendDigestEmail };

--- a/src/services/pdf.js
+++ b/src/services/pdf.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+const PDFDocument = require('pdfkit');
+const dayjs = require('dayjs');
+
+function buildDigest(websiteId, url, captures) {
+  if (!captures.length) {
+    throw new Error('No hay capturas disponibles para generar el PDF.');
+  }
+  const directory = path.join(__dirname, '..', '..', 'storage', 'digests', String(websiteId));
+  fs.mkdirSync(directory, { recursive: true });
+  const filename = `${dayjs().format('YYYY-MM-DD_HH-mm-ss')}.pdf`;
+  const filePath = path.join(directory, filename);
+
+  const doc = new PDFDocument({ autoFirstPage: false });
+  const stream = fs.createWriteStream(filePath);
+  doc.pipe(stream);
+
+  captures.forEach((capture, index) => {
+    const image = fs.readFileSync(capture.image_path);
+    doc.addPage({ size: 'A4', margin: 50 });
+    doc.fontSize(16).text(`Captura ${index + 1} - ${capture.captured_at}`, { align: 'left' });
+    doc.moveDown();
+    const maxWidth = doc.page.width - doc.page.margins.left - doc.page.margins.right;
+    const maxHeight = doc.page.height - doc.y - doc.page.margins.bottom;
+    doc.image(image, {
+      fit: [maxWidth, maxHeight],
+      align: 'center',
+      valign: 'center'
+    });
+  });
+
+  doc.end();
+
+  return new Promise((resolve, reject) => {
+    stream.on('finish', () => resolve(filePath));
+    stream.on('error', reject);
+  });
+}
+
+module.exports = { buildDigest };

--- a/src/services/screenshot.js
+++ b/src/services/screenshot.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+const dayjs = require('dayjs');
+const puppeteer = require('puppeteer');
+const config = require('../config');
+const logger = require('../logger');
+
+let browser;
+
+async function getBrowser() {
+  if (browser) return browser;
+  browser = await puppeteer.launch({
+    headless: 'new',
+    executablePath: config.puppeteer.executablePath || undefined,
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
+  return browser;
+}
+
+async function capture(url, websiteId) {
+  const instance = await getBrowser();
+  const page = await instance.newPage();
+  await page.setViewport({ width: 1280, height: 720 });
+  await page.goto(url, { waitUntil: 'networkidle2', timeout: 60000 });
+
+  const timestamp = dayjs().format('YYYY-MM-DD_HH-mm-ss');
+  const filename = `${timestamp}.png`;
+  const directory = path.join(__dirname, '..', '..', 'storage', 'screenshots', String(websiteId));
+  fs.mkdirSync(directory, { recursive: true });
+  const filePath = path.join(directory, filename);
+  await page.screenshot({ path: filePath, fullPage: true });
+  await page.close();
+  logger.info('Captured screenshot', { url, filePath });
+  return filePath;
+}
+
+async function shutdown() {
+  if (browser) {
+    await browser.close();
+    browser = null;
+  }
+}
+
+module.exports = { capture, shutdown };

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+const storagePath = path.join(__dirname, '..', 'storage', 'data.json');
+
+function ensureFile() {
+  const dir = path.dirname(storagePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  if (!fs.existsSync(storagePath)) {
+    fs.writeFileSync(storagePath, JSON.stringify({ websites: [], captures: [] }, null, 2));
+  }
+}
+
+function read() {
+  ensureFile();
+  const content = fs.readFileSync(storagePath, 'utf-8');
+  return JSON.parse(content);
+}
+
+function write(data) {
+  ensureFile();
+  fs.writeFileSync(storagePath, JSON.stringify(data, null, 2));
+}
+
+module.exports = { read, write };


### PR DESCRIPTION
## Summary
- replace the Python FastAPI service with an Express-based Node.js backend that schedules captures, stores JSON data, and sends emails/PDFs
- add a static web interface to manage monitored websites and review stored screenshots
- update project documentation, environment samples, and scripts for the new web-focused stack

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d72398b268832884e3fc37718f7b49